### PR TITLE
partial fix for schema ID field

### DIFF
--- a/common_fate_schema/tests/v1alpha1_test.py
+++ b/common_fate_schema/tests/v1alpha1_test.py
@@ -47,7 +47,7 @@ def test_v1alpha1(export_schema):
 
 def test_v1alpha1_example(snapshot_json):
     schema = v1alpha1.Schema(
-        provider=v1alpha1.Provider(
+        id=v1alpha1.ID(
             schema_version="v1",
             name="example",
             publisher="common-fate",

--- a/output/provider/v1alpha1
+++ b/output/provider/v1alpha1
@@ -28,6 +28,29 @@
       "title": "Config",
       "type": "object"
     },
+    "ID": {
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "publisher": {
+          "title": "Publisher",
+          "type": "string"
+        },
+        "schema_version": {
+          "title": "Schema Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "publisher",
+        "name",
+        "schema_version"
+      ],
+      "title": "ID",
+      "type": "object"
+    },
     "Loader": {
       "description": "A callable function in the provider which can\nload resources.\n\nAdditional fields for loader configuration may be added\nin a future specification.",
       "properties": {
@@ -51,29 +74,6 @@
         }
       },
       "title": "Meta",
-      "type": "object"
-    },
-    "Provider": {
-      "properties": {
-        "name": {
-          "title": "Name",
-          "type": "string"
-        },
-        "publisher": {
-          "title": "Publisher",
-          "type": "string"
-        },
-        "schema_version": {
-          "title": "Schema Version",
-          "type": "string"
-        }
-      },
-      "required": [
-        "publisher",
-        "name",
-        "schema_version"
-      ],
-      "title": "Provider",
       "type": "object"
     },
     "Resources": {
@@ -165,9 +165,6 @@
     },
     "meta": {
       "$ref": "#/definitions/Meta"
-    },
-    "provider": {
-      "$ref": "#/definitions/Provider"
     },
     "resources": {
       "$ref": "#/definitions/Resources"


### PR DESCRIPTION
The `Provider` field in the schema class is just used to drive the `$id` output in the schema. The field was mistakenly included in the schema itself. this PR partially fixes that, and renames the class to be `ID` so that it isn't confused with the `provider` field in our Describe API call.

It is a partial fix because the `ID` object is still there in the schema definitions, even though it's not intended to be exported. I think the fix is to use JSON schema as the source of truth rather than trying to generate it from Pydantic.